### PR TITLE
Refactored calls to sizeof() macro.

### DIFF
--- a/lib/utils/generator/c_function.ex
+++ b/lib/utils/generator/c_function.ex
@@ -132,8 +132,17 @@ defmodule Utils.Generator.CFunction do
       unsigned int #{var_name}_len;
       enif_get_list_length(env, argv[#{var_number}], &#{var_name}_len);
 
-      char *#{var_name} = enif_alloc(sizeof(char *) * (#{var_name}_len + 1));
-      if (enif_get_string(env, argv[#{var_number}], #{var_name}, sizeof(#{var_name}), ERL_NIF_LATIN1) < 1)
+      unsigned #{var_name}_size = sizeof(char *) * (#{var_name}_len + 1);
+      char *#{var_name} = enif_alloc(#{var_name}_size);
+
+      /*
+      if (!#{var_name}) {
+        // TODO
+        // treat enif_alloc fail
+      }
+      */
+
+      if (enif_get_string(env, argv[#{var_number}], #{var_name}, #{var_name}_size, ERL_NIF_LATIN1) < 1)
         return enif_make_badarg(env);
     """
   end

--- a/src/raylib_core.c
+++ b/src/raylib_core.c
@@ -18,8 +18,17 @@ static ERL_NIF_TERM init_window(ErlNifEnv *env, int argc,
   unsigned int len;
   enif_get_list_length(env, argv[2], &len);
 
-  char *title = enif_alloc(sizeof(char *) * (len + 1));
-  if (enif_get_string(env, argv[2], title, sizeof(title), ERL_NIF_LATIN1) < 1)
+  unsigned title_size = sizeof(char *) * (len + 1);
+  char *title = enif_alloc(title_size);
+
+  /*
+  if (!title) {
+    // TODO
+    // treat enif_alloc fail
+  }
+  */
+
+  if (enif_get_string(env, argv[2], title, title_size, ERL_NIF_LATIN1) < 1)
     return enif_make_badarg(env);
 
   // binding

--- a/test/utils/generator/c_function_test.exs
+++ b/test/utils/generator/c_function_test.exs
@@ -24,8 +24,17 @@ defmodule Utils.Generator.CFunctionTest do
       unsigned int title_len;
       enif_get_list_length(env, argv[2], &title_len);
     
-      char *title = enif_alloc(sizeof(char *) * (title_len + 1));
-      if (enif_get_string(env, argv[2], title, sizeof(title), ERL_NIF_LATIN1) < 1)
+      unsigned title_size = sizeof(char *) * (title_len + 1);
+      char *title = enif_alloc(title_size);
+
+      /*
+      if (!title) {
+        // TODO
+        // treat enif_alloc fail
+      }
+      */
+
+      if (enif_get_string(env, argv[2], title, title_size, ERL_NIF_LATIN1) < 1)
         return enif_make_badarg(env);
     
       // binding


### PR DESCRIPTION
In the original code there are a couple of uses of the sizeof() macro with dynamically allocated memory. This is a issue as sizeof will not be evaluated to the correct value.

However, in the code it is possible to calculate the size of the allocated memory, as it is allocated on the same block where sizeof() is used. Thus I used the known value and replaced the sizeof() calls with it.

I also added some templates for error checking, as the enif_alloc() function can fail and will return NULL if it does. This must be treated, otherwise the program will ungracefully crash.