### PR TITLE
Update to raylib 5.5, add more functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You need the following packages installed on your system:
 * elixir
 * erlang (headers)
 * pkg-config
-* raylib v5
+* raylib v5.5
 * glibc
 * clang-tools (formatter)
 

--- a/c_src/rayex/rayex.c
+++ b/c_src/rayex/rayex.c
@@ -699,10 +699,10 @@ UNIFEX_TERM stop_sound(UnifexEnv *env, UnifexPayload *payload) {
   return stop_sound_result_ok(env);
 }
 
-UNIFEX_TERM is_sound_ready(UnifexEnv *env, UnifexPayload *payload) {
+UNIFEX_TERM is_sound_valid(UnifexEnv *env, UnifexPayload *payload) {
   Sound sound = get_sound_unifex_payload(env, payload);
-  bool res = IsSoundReady(sound);
-  return is_sound_ready_result(env, res);
+  bool res = IsSoundValid(sound);
+  return is_sound_valid_result(env, res);
 }
 
 // AudioStream management functions

--- a/c_src/rayex/rayex.c
+++ b/c_src/rayex/rayex.c
@@ -531,6 +531,11 @@ UNIFEX_TERM draw_poly(UnifexEnv *env, vector2 center, int sides, double radius, 
 
 // Basic shapes collision detection functions
 
+UNIFEX_TERM check_collision_circles(UnifexEnv *env, vector2 c1, double r1, vector2 c2, double r2) {
+  bool res = CheckCollisionCircles(VECTOR2(c1), r1, VECTOR2(c2), r2);
+  return check_collision_circles_result(env, res);
+}
+
 UNIFEX_TERM check_collision_point_rec(UnifexEnv *env, vector2 p, rectangle r) {
   bool res = CheckCollisionPointRec(VECTOR2(p), RECTANGLE(r));
   return check_collision_point_rec_result(env, res);

--- a/c_src/rayex/rayex.c
+++ b/c_src/rayex/rayex.c
@@ -524,6 +524,11 @@ UNIFEX_TERM draw_triangle(UnifexEnv *env, vector2 v1, vector2 v2, vector2 v3,
   return draw_triangle_result_ok(env);
 }
 
+UNIFEX_TERM draw_poly(UnifexEnv *env, vector2 center, int sides, double radius, double rotation, color c) {
+  DrawPoly(VECTOR2(center), sides, radius, rotation, COLOR(c));
+  return draw_poly_result_ok(env);
+}
+
 // Basic shapes collision detection functions
 
 UNIFEX_TERM check_collision_point_rec(UnifexEnv *env, vector2 p, rectangle r) {

--- a/c_src/rayex/rayex.c
+++ b/c_src/rayex/rayex.c
@@ -507,6 +507,11 @@ UNIFEX_TERM draw_rectangle_rec(UnifexEnv *env, rectangle r, color c) {
   return draw_rectangle_rec_result_ok(env);
 }
 
+UNIFEX_TERM draw_rectangle_pro(UnifexEnv *env, rectangle r, vector2 origin, double rotation, color c) {
+  DrawRectanglePro(RECTANGLE(r), VECTOR2(origin), rotation, COLOR(c));
+  return draw_rectangle_pro_result_ok(env);
+}
+
 UNIFEX_TERM draw_rectangle_lines_ex(UnifexEnv *env, rectangle r, int line_thick,
                                     color c) {
   DrawRectangleLinesEx(RECTANGLE(r), line_thick, COLOR(c));

--- a/c_src/rayex/rayex.c
+++ b/c_src/rayex/rayex.c
@@ -243,6 +243,16 @@ UNIFEX_TERM toggle_fullscreen(UnifexEnv *env) {
   return toggle_fullscreen_result_ok(env);
 }
 
+UNIFEX_TERM get_screen_width(UnifexEnv *env) {
+  int res = GetScreenWidth();
+  return get_screen_width_result(env, res);
+}
+
+UNIFEX_TERM get_screen_height(UnifexEnv *env) {
+  int res = GetScreenHeight();
+  return get_screen_height_result(env, res);
+}
+
 // Cursor-related functions
 
 UNIFEX_TERM show_cursor(UnifexEnv *env) {

--- a/c_src/rayex/rayex.c
+++ b/c_src/rayex/rayex.c
@@ -485,6 +485,16 @@ UNIFEX_TERM draw_line(UnifexEnv *env, int start_x, int start_y, int end_x,
   return draw_pixel_result_ok(env);
 }
 
+UNIFEX_TERM draw_circle(UnifexEnv *env, int center_x, int center_y, double radius, color c) {
+  DrawCircle(center_x, center_y, radius, COLOR(c));
+  return draw_circle_result_ok(env);
+}
+
+UNIFEX_TERM draw_circle_v(UnifexEnv *env, vector2 center, double radius, color c) {
+  DrawCircleV(VECTOR2(center), radius, COLOR(c));
+  return draw_circle_v_result_ok(env);
+}
+
 UNIFEX_TERM draw_rectangle_rec(UnifexEnv *env, rectangle r, color c) {
   DrawRectangleRec(RECTANGLE(r), COLOR(c));
   return draw_rectangle_rec_result_ok(env);

--- a/c_src/rayex/rayex.c
+++ b/c_src/rayex/rayex.c
@@ -356,6 +356,13 @@ UNIFEX_TERM get_time(UnifexEnv *env) {
   return get_time_result(env, res);
 }
 
+// Random values generation functions
+
+UNIFEX_TERM get_random_value(UnifexEnv *env, int min, int max) {
+  int res = GetRandomValue(min, max);
+  return get_random_value_result(env, res);
+}
+
 // Misc. functions
 
 // Set custom callbacks

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -59,6 +59,9 @@ spec get_fps() :: fps :: int
 spec get_frame_time() :: delta :: float
 spec get_time() :: time_from_start :: float
 
+# Random values generation functions
+spec get_random_value(min :: int, max :: int) :: result :: int
+
 # Misc. functions
 
 # Set custom callbacks

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -248,7 +248,7 @@ spec get_master_volume() :: volume :: float
 spec load_sound(file_name :: string) :: sound :: payload
 dirty(:io, load_sound: 1)
 
-spec is_sound_ready(sound :: payload) :: result :: bool
+spec is_sound_valid(sound :: payload) :: result :: bool
 
 # Wave/Sound management functions
 

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -24,6 +24,8 @@ spec is_window_state(flag :: int) :: result :: bool
 spec set_window_state(flag :: int) :: :ok :: label
 spec clear_window_state(flag :: int) :: :ok :: label
 spec toggle_fullscreen() :: :ok :: label
+spec get_screen_width() :: result :: int
+spec get_screen_height() :: result :: int
 
 # Cursor-related functions
 

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -148,6 +148,7 @@ spec draw_triangle(v1 :: vector2, v2 :: vector2, v3 :: vector2, color :: color) 
 spec draw_poly(center :: vector2, sides :: int, radius :: float, rotation :: float, color :: color) :: :ok :: label
 
 # Basic shapes collision detection functions
+spec check_collision_circles(center1 :: vector2, radius1 :: float, center2 :: vector2, radius2 :: float) :: result :: bool
 spec check_collision_point_rec(point :: vector2, rec :: rectangle) :: result :: bool
 spec get_ray_collision_box(ray :: ray, box :: bounding_box) :: ray_collision :: ray_collision
 

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -139,16 +139,34 @@ spec draw_pixel(x :: int, y :: int, color :: color) :: :ok :: label
 spec draw_line(start_x :: int, start_y :: int, end_x :: int, end_y :: int, color :: color) ::
        :ok :: label
 
-spec draw_circle(center_x :: int, center_y :: int, radius :: float, color :: color) :: :ok :: label
+spec draw_circle(center_x :: int, center_y :: int, radius :: float, color :: color) ::
+       :ok :: label
+
 spec draw_circle_v(center :: vector2, radius :: float, color :: color) :: :ok :: label
 spec draw_rectangle_rec(rec :: rectangle, color :: color) :: :ok :: label
-spec draw_rectangle_pro(rec :: rectangle, origin :: vector2, rotation :: float, color :: color) :: :ok :: label
+
+spec draw_rectangle_pro(rec :: rectangle, origin :: vector2, rotation :: float, color :: color) ::
+       :ok :: label
+
 spec draw_rectangle_lines_ex(rec :: rectangle, line_thick :: int, color :: color) :: :ok :: label
 spec draw_triangle(v1 :: vector2, v2 :: vector2, v3 :: vector2, color :: color) :: :ok :: label
-spec draw_poly(center :: vector2, sides :: int, radius :: float, rotation :: float, color :: color) :: :ok :: label
+
+spec draw_poly(
+       center :: vector2,
+       sides :: int,
+       radius :: float,
+       rotation :: float,
+       color :: color
+     ) :: :ok :: label
 
 # Basic shapes collision detection functions
-spec check_collision_circles(center1 :: vector2, radius1 :: float, center2 :: vector2, radius2 :: float) :: result :: bool
+spec check_collision_circles(
+       center1 :: vector2,
+       radius1 :: float,
+       center2 :: vector2,
+       radius2 :: float
+     ) :: result :: bool
+
 spec check_collision_point_rec(point :: vector2, rec :: rectangle) :: result :: bool
 spec get_ray_collision_box(ray :: ray, box :: bounding_box) :: ray_collision :: ray_collision
 

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -145,6 +145,7 @@ spec draw_rectangle_rec(rec :: rectangle, color :: color) :: :ok :: label
 spec draw_rectangle_pro(rec :: rectangle, origin :: vector2, rotation :: float, color :: color) :: :ok :: label
 spec draw_rectangle_lines_ex(rec :: rectangle, line_thick :: int, color :: color) :: :ok :: label
 spec draw_triangle(v1 :: vector2, v2 :: vector2, v3 :: vector2, color :: color) :: :ok :: label
+spec draw_poly(center :: vector2, sides :: int, radius :: float, rotation :: float, color :: color) :: :ok :: label
 
 # Basic shapes collision detection functions
 spec check_collision_point_rec(point :: vector2, rec :: rectangle) :: result :: bool

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -142,6 +142,7 @@ spec draw_line(start_x :: int, start_y :: int, end_x :: int, end_y :: int, color
 spec draw_circle(center_x :: int, center_y :: int, radius :: float, color :: color) :: :ok :: label
 spec draw_circle_v(center :: vector2, radius :: float, color :: color) :: :ok :: label
 spec draw_rectangle_rec(rec :: rectangle, color :: color) :: :ok :: label
+spec draw_rectangle_pro(rec :: rectangle, origin :: vector2, rotation :: float, color :: color) :: :ok :: label
 spec draw_rectangle_lines_ex(rec :: rectangle, line_thick :: int, color :: color) :: :ok :: label
 spec draw_triangle(v1 :: vector2, v2 :: vector2, v3 :: vector2, color :: color) :: :ok :: label
 

--- a/c_src/rayex/rayex.spec.exs
+++ b/c_src/rayex/rayex.spec.exs
@@ -136,6 +136,8 @@ spec draw_pixel(x :: int, y :: int, color :: color) :: :ok :: label
 spec draw_line(start_x :: int, start_y :: int, end_x :: int, end_y :: int, color :: color) ::
        :ok :: label
 
+spec draw_circle(center_x :: int, center_y :: int, radius :: float, color :: color) :: :ok :: label
+spec draw_circle_v(center :: vector2, radius :: float, color :: color) :: :ok :: label
 spec draw_rectangle_rec(rec :: rectangle, color :: color) :: :ok :: label
 spec draw_rectangle_lines_ex(rec :: rectangle, line_thick :: int, color :: color) :: :ok :: label
 spec draw_triangle(v1 :: vector2, v2 :: vector2, v3 :: vector2, color :: color) :: :ok :: label

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724479785,
-        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {

--- a/lib/rayex/audio.ex
+++ b/lib/rayex/audio.ex
@@ -26,9 +26,9 @@ defmodule Rayex.Audio do
   @spec load_sound(String.t()) :: S.Sound.t()
   defdelegate load_sound(fileName), to: Raylib
 
-  @doc "Checks if a sound is ready"
-  @spec is_sound_ready?(S.Sound.t()) :: boolean()
-  defdelegate is_sound_ready?(sound), to: Raylib, as: :is_sound_ready
+  @doc "Checks if a sound is valid (data loaded and buffers initialized)"
+  @spec is_sound_valid?(S.Sound.t()) :: boolean()
+  defdelegate is_sound_valid?(sound), to: Raylib, as: :is_sound_valid
 
   # Wave/Sound management functions
 

--- a/lib/rayex/core.ex
+++ b/lib/rayex/core.ex
@@ -64,6 +64,14 @@ defmodule Rayex.Core do
   @spec toggle_fullscreen() :: :ok
   defdelegate toggle_fullscreen, to: Raylib
 
+  @doc "Get current screen width"
+  @spec get_screen_width() :: integer()
+  defdelegate get_screen_width, to: Raylib
+
+  @doc "Get current screen height"
+  @spec get_screen_height() :: integer()
+  defdelegate get_screen_height, to: Raylib
+
   # Cursor-related functions
 
   @doc "Shows cursor"

--- a/lib/rayex/core.ex
+++ b/lib/rayex/core.ex
@@ -156,6 +156,12 @@ defmodule Rayex.Core do
   @spec get_time() :: float()
   defdelegate get_time, to: Raylib
 
+  # Random values generation functions
+
+  @doc "Get a random value between min and max (both included)"
+  @spec get_random_value(integer(), integer()) :: integer()
+  defdelegate get_random_value(min, max), to: Raylib
+
   # Misc. functions
 
   # Set custom callbacks

--- a/lib/rayex/shapes.ex
+++ b/lib/rayex/shapes.ex
@@ -24,6 +24,14 @@ defmodule Rayex.Shapes do
   @spec draw_line(integer(), integer(), integer(), integer(), S.Color.t()) :: :ok
   defdelegate draw_line(start_x, start_y, end_x, end_y, color), to: Raylib
 
+  @doc "Draw a color-filled circle"
+  @spec draw_circle(integer(), integer(), float(), S.Color.t()) :: :ok
+  defdelegate draw_circle(center_x, center_y, radius, color), to: Raylib
+
+  @doc "Draw a color-filled circle (Vector version)"
+  @spec draw_circle_v(S.Vector2.t(), float(), S.Color.t()) :: :ok
+  defdelegate draw_circle_v(center, radius, color), to: Raylib
+
   @doc "Draw a color-filled rectangle"
   @spec draw_rectangle_rec(S.Rectangle.t(), S.Color.t()) :: :ok
   defdelegate draw_rectangle_rec(rectangle, color), to: Raylib

--- a/lib/rayex/shapes.ex
+++ b/lib/rayex/shapes.ex
@@ -36,6 +36,10 @@ defmodule Rayex.Shapes do
   @spec draw_rectangle_rec(S.Rectangle.t(), S.Color.t()) :: :ok
   defdelegate draw_rectangle_rec(rectangle, color), to: Raylib
 
+  @doc "Draw a color-filled rectangle with pro parameters"
+  @spec draw_rectangle_pro(S.Rectangle.t(), S.Vector2.t(), float(), S.Color.t()) :: :ok
+  defdelegate draw_rectangle_pro(rectangle, origin, rotation, color), to: Raylib
+
   @doc "Draw rectangle outline with extended parameters"
   @spec draw_rectangle_lines_ex(S.Rectangle.t(), integer(), S.Color.t()) :: :ok
   defdelegate draw_rectangle_lines_ex(rectangle, line_thick, color), to: Raylib

--- a/lib/rayex/shapes.ex
+++ b/lib/rayex/shapes.ex
@@ -48,6 +48,10 @@ defmodule Rayex.Shapes do
   @spec draw_triangle(S.Vector2.t(), S.Vector2.t(), S.Vector2.t(), S.Color.t()) :: :ok
   defdelegate draw_triangle(vertice1, vertice2, vertice3, color), to: Raylib
 
+  @doc "Draw a regular polygon (Vector version)"
+  @spec draw_poly(S.Vector2.t(), integer(), float(), float(), S.Color.t()) :: :ok
+  defdelegate draw_poly(center, sides, radius, rotation, color), to: Raylib
+
   # Basic shapes collision detection functions
 
   @doc "Check if point is inside rectangle"

--- a/lib/rayex/shapes.ex
+++ b/lib/rayex/shapes.ex
@@ -54,6 +54,10 @@ defmodule Rayex.Shapes do
 
   # Basic shapes collision detection functions
 
+  @doc "Check collision between two circles"
+  @spec check_collision_circles(S.Vector2.t(), float(), S.Vector2.t(), float()) :: boolean()
+  defdelegate check_collision_circles(center1, radius1, center2, radius2), to: Raylib
+
   @doc "Check if point is inside rectangle"
   @spec check_collision_point_rec(S.Vector2.t(), S.Rectangle.t()) :: boolean()
   defdelegate check_collision_point_rec(point, rectangle), to: Raylib


### PR DESCRIPTION
This updates the library for raylib 5.5 by renaming `is_sound_ready?` to `is_sound_valid?`.
I also uploaded the flake since the new version finally got merged into nixpkgs.

This also adds some functions that I've been using while trying out raylib in my own Elixir project over on: https://codeberg.org/qtea/expel